### PR TITLE
small fixes for typo and formats

### DIFF
--- a/deployment/admissionregistration.yaml
+++ b/deployment/admissionregistration.yaml
@@ -1,23 +1,22 @@
-apiVersion: admissionregistration.k8s.io/v1lapha1
+apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ExternalAdmissionHookConfiguration
 metadata:
   name: config1
-spec:
-  externalAdmissionHooks:
-    - name: podimage
-      rules:
-        - operations:
-            - CREATE
-          apiGroups:
-            - ""
-          apiVersions:
-            - v1
-          resources:
-            - pods
-      failurePolicy: Fail
-      clientConfig:
-        service:
-          namespace: default
-          name: webhook
-        caBundle:
-          
+externalAdmissionHooks:
+  - name: podimage.k8s.io
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        namespace: default
+        name: webhook
+      caBundle:
+        


### PR DESCRIPTION
"Fail" failurePolicy also seems to be invalid for Kubernetes v1.8.0.